### PR TITLE
Added support for PACKAGES.[extension]

### DIFF
--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RRecipeSupport.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RRecipeSupport.groovy
@@ -113,7 +113,7 @@ abstract class RRecipeSupport
     new Builder().matcher(
         LogicMatchers.and(
             new ActionMatcher(GET, HEAD),
-            new TokenMatcher('/{path:.+}/PACKAGES.gz')
+            new TokenMatcher('/{path:.+}/PACKAGES{extension:.*}')
         ))
   }
 


### PR DESCRIPTION
To be able to match PACKAGES, PACKAGES.gz and PACKAGES.rds

It relates to the following issue #s:
* https://github.com/sonatype/nexus-repository-r/issues/5
* https://github.com/sonatype/nexus-repository-r/issues/10
