### PR TITLE
Link updates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@
 much shaming throughout the land. If you use an editor besides Eclipse or IntelliJ, adapt the codestyle and submit a PR
 there :)
 * Fill out a CLA for us, so we can sort out all the legal parts of contributing. You can get all the information for
-this [here](https://books.sonatype.com/nexus-book/reference/contrib.html). You may go, this is for your book, is it
+this [here](https://help.sonatype.com/display/NXRM3/Bundle+Development#BundleDevelopment-ContributingBundles). You may go, this is for your book, is it
 applicable for this repo? Yes, absolutely. Follow the CLA process and email in your form. We are working on a way to
 make this simpler, as well.
 * Make sure to fill out an issue for your PR, so that we have traceability as to what you are trying to fix,

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ we would like things to flow.
 * [Java 8+](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 * Network access to https://repository.sonatype.org/content/groups/sonatype-public-grid
 
-Also, there is a good amount of information available at [Bundle Development](https://books.sonatype.com/nexus-book/reference3/bundle-development.html#bundle-development-overview)
+Also, there is a good amount of information available at [Bundle Development](https://help.sonatype.com/display/NXRM3/Bundle+Development#BundleDevelopment-BundleDevelopmentOverview)
 
 ### Building
 
@@ -67,7 +67,7 @@ good installation path if you are just testing or doing development on the plugi
 
 * Enable Nexus console: edit `<nexus_dir>/bin/nexus.vmoptions` and change `karaf.startLocalConsole`  to `true`.
 
-  More details here: http://books.sonatype.com/nexus-book/reference3/bundle-development.html
+  More details here: https://help.sonatype.com/display/NXRM3/Bundle+Development#BundleDevelopment-InstallingBundles
 
 * Run Nexus' console:
   ```

--- a/docs/R_USER_DOCUMENTATION.md
+++ b/docs/R_USER_DOCUMENTATION.md
@@ -37,7 +37,7 @@ a hosted repository.
 You can set up an R proxy repository to access a remote repository location, for example the official R
 registry at [https://cran.r-project.org/](https://cran.r-project.org/) that is configured as the default in R.
 
-To proxy a R repository, you simply create a new 'r (proxy)' as documented in [admin repositories](http://books.sonatype.com/nexus-book/reference3/admin.html#admin-repositories) in
+To proxy a R repository, you simply create a new 'r (proxy)' as documented in [Repository Management](https://help.sonatype.com/display/NXRM3/Configuration#Configuration-RepositoryManagement) in
 details. Minimal configuration steps are:
 
 - Define 'Name'
@@ -50,7 +50,7 @@ Creating a R hosted repository allows you to register packages in the repository
 repository acts as an authoritative location for these components.
 
 To add a hosted R repository, create a new repository with the recipe 'r (hosted)' as
-documented in [admin repositories](http://books.sonatype.com/nexus-book/reference3/admin.html#admin-repositories).
+documented in [Repository Management](https://help.sonatype.com/display/NXRM3/Configuration#Configuration-RepositoryManagement).
 
 Minimal configuration steps are:
 
@@ -63,7 +63,7 @@ A repository group is the recommended way to expose all your R repositories from
 your users, with minimal additional client side configuration. A repository group allows you to expose the
 aggregated content of multiple proxy and hosted repositories as well as other repository groups with one URL in
 tool configuration. This is possible for R repositories by creating a new repository with the 'r (group)'
-recipe as documented in [admin repositories](http://books.sonatype.com/nexus-book/reference3/admin.html#admin-repositories).
+recipe as documented in [Repository Management](https://help.sonatype.com/display/NXRM3/Configuration#Configuration-RepositoryManagement).
 
 Minimal configuration steps are:
 
@@ -104,7 +104,7 @@ inspected in the user interface.
 ### Browsing R Repositories and Searching Packages
 
 You can browse R repositories in the user interface inspecting the components and assets and their details, as
-described in [search-components](http://books.sonatype.com/nexus-book/reference3/using.html#search-components).
+described in [Search for Components](https://help.sonatype.com/display/NXRM3/User+Interface#UserInterface-SearchingforComponents).
 
 Searching for R packages can be performed in the user interface, too. It finds all packages that are currently
 stored in the repository manager, either because they have been pushed to a hosted repository or they have been
@@ -120,7 +120,6 @@ Authentication is managed in the same manner as for proxying with anonymous acce
 [r-download](#configuring-r-package-download).
 
 With this configuration you can run a command such as
-
 
 `curl -v --user 'user:pass' --upload-file example_1.0.0.tar.gz http://localhost:8081/repository/r-hosted/src/contrib/example_1.0.0.tar.gz`
 


### PR DESCRIPTION
Since switching over to help.sonatype.com, none of the links work here anymore! Oh noes! Fixing that up.

This pull request makes the following changes:
* Updates old book links to the hopefully right help.sonatype.com links
