### PR TITLE
Correctly generate PACKAGES information for R hosted repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
     </dependency>
 
     <dependency>
+      <groupId>se.sawano.java</groupId>
+      <artifactId>alphanumeric-comparator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.sonatype.goodies</groupId>
       <artifactId>goodies-testsupport</artifactId>
       <scope>test</scope>

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RPackageVersion.java
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RPackageVersion.java
@@ -1,0 +1,113 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.r.internal;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import se.sawano.java.text.AlphanumericComparator;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Class representing a single valid R package version that can be compared to other versions. Specifically this class
+ * is intended to be used to compare R version strings when merging group metadata.
+ *
+ * Version formats explicitly supported/tested are those that include digits separated by dots or dashes per the R
+ * documentation that is publicly available on the matter, but this is not internally enforced (and using other version
+ * schemes will result in undefined behavior). Refer to R's {@code package_version} and {@code utils::compareVersions}
+ * functions for implementation details.
+ */
+public class RPackageVersion
+    implements Comparable<RPackageVersion>
+{
+  /**
+   * An alphanumeric comparator that will produce the proper ordering for R version strings.
+   */
+  private static final AlphanumericComparator versionComparator = new AlphanumericComparator(Locale.US);
+
+  /**
+   * The version string as originally provided, maintaining its original format and separators.
+   */
+  private final String originalVersion;
+
+  /**
+   * The normalized version string with all dashes replaced with dots for quick alphanumeric comparison.
+   */
+  private final String normalizedVersion;
+
+  /**
+   * Constructor.
+   *
+   * @param version The version string.
+   */
+  public RPackageVersion(final String version) {
+    this.originalVersion = checkNotNull(version).trim();
+    this.normalizedVersion = originalVersion.replaceAll("-", ".");
+  }
+
+  /**
+   * Compares two {@code RPackageVersion}s with the assumption that both are valid version strings.
+   *
+   * @param other The {@code RPackageVersion} with which to compare.
+   * @return Integer indicating if the version is less than, equal to, or greater than this version.
+   */
+  @Override
+  public int compareTo(final RPackageVersion other) {
+    return versionComparator.compare(normalizedVersion, other.normalizedVersion);
+  }
+
+  /**
+   * Returns whether or not this {@code RPackageVersion} is equal to another object. For purposes of the comparison,
+   * the two will be equal if and only if both are {@code RPackageVersion}s and their normalized version strings are
+   * equal.
+   *
+   * @param o The other object.
+   * @return {@code true} if equal, {@code false} otherwise
+   */
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RPackageVersion that = (RPackageVersion) o;
+    return Objects.equals(normalizedVersion, that.normalizedVersion);
+  }
+
+  /**
+   * Returns a hash code for this {@code RPackageVersion} derived from the hash code for the normalized version string.
+   *
+   * @return The hash code for this {@code RPackageVersion}.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(normalizedVersion);
+  }
+
+  /**
+   * Returns a string representation containing both the original version string and its normalized representation
+   * internal to the instance.
+   *
+   * @return The string representation.
+   */
+  @Override
+  public String toString() {
+    return "RPackageVersion{" +
+        "originalVersion='" + originalVersion + '\'' +
+        ", normalizedVersion='" + normalizedVersion + '\'' +
+        '}';
+  }
+}

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RPackageVersion.java
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RPackageVersion.java
@@ -20,13 +20,11 @@ import se.sawano.java.text.AlphanumericComparator;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Class representing a single valid R package version that can be compared to other versions. Specifically this class
- * is intended to be used to compare R version strings when merging group metadata.
+ * Class representing a single valid R package version that can be compared to other versions. Version formats
+ * explicitly supported/tested are those that include digits separated by dots or dashes, but this is not internally
+ * enforced (and using other version schemes will result in undefined behavior).
  *
- * Version formats explicitly supported/tested are those that include digits separated by dots or dashes per the R
- * documentation that is publicly available on the matter, but this is not internally enforced (and using other version
- * schemes will result in undefined behavior). Refer to R's {@code package_version} and {@code utils::compareVersions}
- * functions for implementation details.
+ * Refer to R's {@code package_version} and {@code utils::compareVersions} functions for implementation details.
  */
 public class RPackageVersion
     implements Comparable<RPackageVersion>

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilder.java
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilder.java
@@ -1,0 +1,119 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.r.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.sonatype.nexus.repository.storage.Asset;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Collections.unmodifiableMap;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_DEPENDS;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_IMPORTS;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_LICENSE;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_NEEDS_COMPILATION;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_PACKAGE;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_SUGGESTS;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_VERSION;
+
+/**
+ * Builds the contents of a PACKAGES file based on the provided assets, taking into account the greatest version of a
+ * particular package that is available in a (hosted) repository.
+ *
+ * Note that this maintains all pertinent information for the "latest" version of each package in memory, though the
+ * actual amount of information for each package is rather small.
+ *
+ * TODO: Ensure that we build this information and actually cache it, rather than doing this for each request.
+ */
+public class RPackagesBuilder
+{
+  /**
+   * The greatest version of each package currently encountered during this run.
+   */
+  private final Map<String, RPackageVersion> packageVersions = new HashMap<>();
+
+  /**
+   * The package information as of the last time we processed the greatest version of this package. A {@code TreeMap} is
+   * used to maintain ordering by package name.
+   */
+  private final Map<String, Map<String, String>> packageInformation = new TreeMap<>();
+
+  /**
+   * The path to the PACKAGES file that is being generated.
+   */
+  private final String packagesPath;
+
+  /**
+   * Constructor.
+   *
+   * @param packagesPath The path to the PACKAGES file that is being generated.
+   */
+  public RPackagesBuilder(final String packagesPath) {
+    this.packagesPath = checkNotNull(packagesPath);
+  }
+
+  /**
+   * Processes an asset, updating the greatest version and details for the package if appropriate.
+   *
+   * @param asset The asset to process.
+   */
+  public void append(final Asset asset) {
+    String base = basePath(packagesPath);
+    String packageName = asset.formatAttributes().get(P_PACKAGE, String.class);
+
+    // is this asset at this particular path?
+    if (base.equals(basePath(asset.name()))) {
+
+      // have we seen a greater version of this already?
+      RPackageVersion newVersion = new RPackageVersion(asset.formatAttributes().get(P_VERSION, String.class));
+      RPackageVersion oldVersion = packageVersions.getOrDefault(packageName, newVersion);
+      if (newVersion.compareTo(oldVersion) >= 0) {
+
+        // if so, use the most recent information instead and update the greatest version encountered
+        Map<String, String> newInformation = new HashMap<>();
+        newInformation.put(P_PACKAGE, asset.formatAttributes().get(P_PACKAGE, String.class));
+        newInformation.put(P_VERSION, asset.formatAttributes().get(P_VERSION, String.class));
+        newInformation.put(P_DEPENDS, asset.formatAttributes().get(P_DEPENDS, String.class));
+        newInformation.put(P_IMPORTS, asset.formatAttributes().get(P_IMPORTS, String.class));
+        newInformation.put(P_SUGGESTS, asset.formatAttributes().get(P_SUGGESTS, String.class));
+        newInformation.put(P_LICENSE, asset.formatAttributes().get(P_LICENSE, String.class));
+        newInformation.put(P_NEEDS_COMPILATION, asset.formatAttributes().get(P_NEEDS_COMPILATION, String.class));
+
+        packageVersions.put(packageName, newVersion);
+        packageInformation.put(packageName, newInformation);
+      }
+    }
+  }
+
+  /**
+   * Returns an unmodifiable map containing the package information to write to a PACKAGES file. The iteration order
+   * of the map's keys is such that the package names will be returned in sorted order.
+   *
+   * @return The map of package information, keyed by package name.
+   */
+  public Map<String, Map<String, String>> getPackageInformation() {
+    return unmodifiableMap(packageInformation);
+  }
+
+  /**
+   * Returns a base path for a particular path (the path excluding the filename and last trailing slash).
+   *
+   * @param path The input path.
+   * @return The base path.
+   */
+  private String basePath(final String path) {
+    return path.substring(0, path.lastIndexOf('/'));
+  }
+}

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilder.java
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilder.java
@@ -70,13 +70,12 @@ public class RPackagesBuilder
    * @param asset The asset to process.
    */
   public void append(final Asset asset) {
-    String base = basePath(packagesPath);
-    String packageName = asset.formatAttributes().get(P_PACKAGE, String.class);
-
     // is this asset at this particular path?
+    String base = basePath(packagesPath);
     if (base.equals(basePath(asset.name()))) {
 
-      // have we seen a greater version of this already?
+      // is this a newer (or equal) version of this asset's package than the one we currently have?
+      String packageName = asset.formatAttributes().get(P_PACKAGE, String.class);
       RPackageVersion newVersion = new RPackageVersion(asset.formatAttributes().get(P_VERSION, String.class));
       RPackageVersion oldVersion = packageVersions.getOrDefault(packageName, newVersion);
       if (newVersion.compareTo(oldVersion) >= 0) {

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilder.java
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilder.java
@@ -74,11 +74,11 @@ public class RPackagesBuilder
     String base = basePath(packagesPath);
     if (base.equals(basePath(asset.name()))) {
 
-      // is this a newer (or equal) version of this asset's package than the one we currently have?
+      // is this a newer version of this asset's package than the one we currently have (if we have one)?
       String packageName = asset.formatAttributes().get(P_PACKAGE, String.class);
+      RPackageVersion oldVersion = packageVersions.get(packageName);
       RPackageVersion newVersion = new RPackageVersion(asset.formatAttributes().get(P_VERSION, String.class));
-      RPackageVersion oldVersion = packageVersions.getOrDefault(packageName, newVersion);
-      if (newVersion.compareTo(oldVersion) >= 0) {
+      if (oldVersion == null || newVersion.compareTo(oldVersion) > 0) {
 
         // if so, use the most recent information instead and update the greatest version encountered
         Map<String, String> newInformation = new HashMap<>();

--- a/src/test/java/org/sonatype/nexus/repository/r/internal/RPackageVersionTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/r/internal/RPackageVersionTest.java
@@ -1,0 +1,235 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.r.internal;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+/**
+ * {@link RPackageVersion} unit tests.
+ */
+public class RPackageVersionTest
+    extends TestSupport
+{
+  @Test
+  public void testComparingGreaterVersions() {
+    // comparing dot versions to dot versions
+    assertThat(new RPackageVersion("0.0.2"), is(greaterThan(new RPackageVersion("0.0.1"))));
+    assertThat(new RPackageVersion("0.2.0"), is(greaterThan(new RPackageVersion("0.1.0"))));
+    assertThat(new RPackageVersion("0.2.0"), is(greaterThan(new RPackageVersion("0.1.1"))));
+    assertThat(new RPackageVersion("1.0.0"), is(greaterThan(new RPackageVersion("0.0.1"))));
+    assertThat(new RPackageVersion("1.0.0"), is(greaterThan(new RPackageVersion("0.1.0"))));
+    assertThat(new RPackageVersion("1.2.0"), is(greaterThan(new RPackageVersion("1.1.0"))));
+    assertThat(new RPackageVersion("1.2.0"), is(greaterThan(new RPackageVersion("1.1.9"))));
+    assertThat(new RPackageVersion("2.0.0"), is(greaterThan(new RPackageVersion("1.0.0"))));
+    assertThat(new RPackageVersion("2.0.0"), is(greaterThan(new RPackageVersion("1.1.0"))));
+    assertThat(new RPackageVersion("2.0.0"), is(greaterThan(new RPackageVersion("1.9.9"))));
+    assertThat(new RPackageVersion("10.0.0"), is(greaterThan(new RPackageVersion("1.0.0"))));
+    assertThat(new RPackageVersion("10.0.0"), is(greaterThan(new RPackageVersion("9.9.9999"))));
+    assertThat(new RPackageVersion("10.0.0"), is(greaterThan(new RPackageVersion("9.9999.9999"))));
+
+    // comparing dot-dash versions to dot-dash versions
+    assertThat(new RPackageVersion("0.0-2"), is(greaterThan(new RPackageVersion("0.0-1"))));
+    assertThat(new RPackageVersion("0.2-0"), is(greaterThan(new RPackageVersion("0.1-0"))));
+    assertThat(new RPackageVersion("0.2-0"), is(greaterThan(new RPackageVersion("0.1-1"))));
+    assertThat(new RPackageVersion("1.0-0"), is(greaterThan(new RPackageVersion("0.0-1"))));
+    assertThat(new RPackageVersion("1.0-0"), is(greaterThan(new RPackageVersion("0.1-0"))));
+    assertThat(new RPackageVersion("1.2-0"), is(greaterThan(new RPackageVersion("1.1-0"))));
+    assertThat(new RPackageVersion("1.2-0"), is(greaterThan(new RPackageVersion("1.1-9"))));
+    assertThat(new RPackageVersion("2.0-0"), is(greaterThan(new RPackageVersion("1.0-0"))));
+    assertThat(new RPackageVersion("2.0-0"), is(greaterThan(new RPackageVersion("1.1-0"))));
+    assertThat(new RPackageVersion("2.0-0"), is(greaterThan(new RPackageVersion("1.9-9"))));
+    assertThat(new RPackageVersion("10.0-0"), is(greaterThan(new RPackageVersion("1.0-0"))));
+    assertThat(new RPackageVersion("10.0-0"), is(greaterThan(new RPackageVersion("9.9-9999"))));
+    assertThat(new RPackageVersion("10.0-0"), is(greaterThan(new RPackageVersion("9.9999-9999"))));
+
+    // comparing dot versions to dot-dash versions
+    assertThat(new RPackageVersion("0.0.2"), is(greaterThan(new RPackageVersion("0.0-1"))));
+    assertThat(new RPackageVersion("0.2.0"), is(greaterThan(new RPackageVersion("0.1-0"))));
+    assertThat(new RPackageVersion("0.2.0"), is(greaterThan(new RPackageVersion("0.1-1"))));
+    assertThat(new RPackageVersion("1.0.0"), is(greaterThan(new RPackageVersion("0.0-1"))));
+    assertThat(new RPackageVersion("1.0.0"), is(greaterThan(new RPackageVersion("0.1-0"))));
+    assertThat(new RPackageVersion("1.2.0"), is(greaterThan(new RPackageVersion("1.1-0"))));
+    assertThat(new RPackageVersion("1.2.0"), is(greaterThan(new RPackageVersion("1.1-9"))));
+    assertThat(new RPackageVersion("2.0.0"), is(greaterThan(new RPackageVersion("1.0-0"))));
+    assertThat(new RPackageVersion("2.0.0"), is(greaterThan(new RPackageVersion("1.1-0"))));
+    assertThat(new RPackageVersion("2.0.0"), is(greaterThan(new RPackageVersion("1.9-9"))));
+    assertThat(new RPackageVersion("10.0.0"), is(greaterThan(new RPackageVersion("1.0-0"))));
+    assertThat(new RPackageVersion("10.0.0"), is(greaterThan(new RPackageVersion("9.9-9999"))));
+    assertThat(new RPackageVersion("10.0.0"), is(greaterThan(new RPackageVersion("9.9999-9999"))));
+
+    // comparing dot-dash versions to dot versions
+    assertThat(new RPackageVersion("0.0-2"), is(greaterThan(new RPackageVersion("0.0.1"))));
+    assertThat(new RPackageVersion("0.2-0"), is(greaterThan(new RPackageVersion("0.1.0"))));
+    assertThat(new RPackageVersion("0.2-0"), is(greaterThan(new RPackageVersion("0.1.1"))));
+    assertThat(new RPackageVersion("1.0-0"), is(greaterThan(new RPackageVersion("0.0.1"))));
+    assertThat(new RPackageVersion("1.0-0"), is(greaterThan(new RPackageVersion("0.1.0"))));
+    assertThat(new RPackageVersion("1.2-0"), is(greaterThan(new RPackageVersion("1.1.0"))));
+    assertThat(new RPackageVersion("1.2-0"), is(greaterThan(new RPackageVersion("1.1.9"))));
+    assertThat(new RPackageVersion("2.0-0"), is(greaterThan(new RPackageVersion("1.0.0"))));
+    assertThat(new RPackageVersion("2.0-0"), is(greaterThan(new RPackageVersion("1.1.0"))));
+    assertThat(new RPackageVersion("2.0-0"), is(greaterThan(new RPackageVersion("1.9.9"))));
+    assertThat(new RPackageVersion("10.0-0"), is(greaterThan(new RPackageVersion("1.0.0"))));
+    assertThat(new RPackageVersion("10.0-0"), is(greaterThan(new RPackageVersion("9.9.9999"))));
+    assertThat(new RPackageVersion("10.0-0"), is(greaterThan(new RPackageVersion("9.9999.9999"))));
+  }
+
+  @Test
+  public void testComparingEqualVersions() {
+    // comparing dot versions to dot versions
+    assertThat(new RPackageVersion("0.0.2"), is(equalTo(new RPackageVersion("0.0.2"))));
+    assertThat(new RPackageVersion("0.2.0"), is(equalTo(new RPackageVersion("0.2.0"))));
+    assertThat(new RPackageVersion("0.2.2"), is(equalTo(new RPackageVersion("0.2.2"))));
+    assertThat(new RPackageVersion("1.0.0"), is(equalTo(new RPackageVersion("1.0.0"))));
+    assertThat(new RPackageVersion("1.2.0"), is(equalTo(new RPackageVersion("1.2.0"))));
+    assertThat(new RPackageVersion("10.0.0"), is(equalTo(new RPackageVersion("10.0.0"))));
+    assertThat(new RPackageVersion("9.9999.9999"), is(equalTo(new RPackageVersion("9.9999.9999"))));
+
+    // comparing dot-dash versions to dot-dash versions
+    assertThat(new RPackageVersion("0.0-2"), is(equalTo(new RPackageVersion("0.0-2"))));
+    assertThat(new RPackageVersion("0.2-0"), is(equalTo(new RPackageVersion("0.2-0"))));
+    assertThat(new RPackageVersion("0.2-2"), is(equalTo(new RPackageVersion("0.2-2"))));
+    assertThat(new RPackageVersion("1.0-0"), is(equalTo(new RPackageVersion("1.0-0"))));
+    assertThat(new RPackageVersion("1.2-0"), is(equalTo(new RPackageVersion("1.2-0"))));
+    assertThat(new RPackageVersion("10.0-0"), is(equalTo(new RPackageVersion("10.0-0"))));
+    assertThat(new RPackageVersion("9.9999-9999"), is(equalTo(new RPackageVersion("9.9999-9999"))));
+
+    // comparing dot versions to dot-dash versions
+    assertThat(new RPackageVersion("0.0.2"), is(equalTo(new RPackageVersion("0.0-2"))));
+    assertThat(new RPackageVersion("0.2.0"), is(equalTo(new RPackageVersion("0.2-0"))));
+    assertThat(new RPackageVersion("0.2.2"), is(equalTo(new RPackageVersion("0.2-2"))));
+    assertThat(new RPackageVersion("1.0.0"), is(equalTo(new RPackageVersion("1.0-0"))));
+    assertThat(new RPackageVersion("1.2.0"), is(equalTo(new RPackageVersion("1.2-0"))));
+    assertThat(new RPackageVersion("10.0.0"), is(equalTo(new RPackageVersion("10.0-0"))));
+    assertThat(new RPackageVersion("9.9999.9999"), is(equalTo(new RPackageVersion("9.9999-9999"))));
+
+    // comparing dot-dash versions to dot versions
+    assertThat(new RPackageVersion("0.0-2"), is(equalTo(new RPackageVersion("0.0.2"))));
+    assertThat(new RPackageVersion("0.2-0"), is(equalTo(new RPackageVersion("0.2.0"))));
+    assertThat(new RPackageVersion("0.2-2"), is(equalTo(new RPackageVersion("0.2.2"))));
+    assertThat(new RPackageVersion("1.0-0"), is(equalTo(new RPackageVersion("1.0.0"))));
+    assertThat(new RPackageVersion("1.2-0"), is(equalTo(new RPackageVersion("1.2.0"))));
+    assertThat(new RPackageVersion("10.0-0"), is(equalTo(new RPackageVersion("10.0.0"))));
+    assertThat(new RPackageVersion("9.9999-9999"), is(equalTo(new RPackageVersion("9.9999.9999"))));
+  }
+
+  @Test
+  public void testComparingNotEqualVersions() {
+    // comparing dot versions to dot versions
+    assertThat(new RPackageVersion("0.0.2"), is(not(equalTo(new RPackageVersion("0.0.1")))));
+    assertThat(new RPackageVersion("0.2.0"), is(not(equalTo(new RPackageVersion("0.1.0")))));
+    assertThat(new RPackageVersion("0.2.2"), is(not(equalTo(new RPackageVersion("0.2.1")))));
+    assertThat(new RPackageVersion("1.0.0"), is(not(equalTo(new RPackageVersion("1.0.1")))));
+    assertThat(new RPackageVersion("1.2.0"), is(not(equalTo(new RPackageVersion("1.0.0")))));
+    assertThat(new RPackageVersion("10.0.0"), is(not(equalTo(new RPackageVersion("10.0.1")))));
+    assertThat(new RPackageVersion("9.9999.9999"), is(not(equalTo(new RPackageVersion("9.9999.9998")))));
+
+    // comparing dot-dash versions to dot-dash versions
+    assertThat(new RPackageVersion("0.0-2"), is(not(equalTo(new RPackageVersion("0.0-1")))));
+    assertThat(new RPackageVersion("0.2-0"), is(not(equalTo(new RPackageVersion("0.1-0")))));
+    assertThat(new RPackageVersion("0.2-2"), is(not(equalTo(new RPackageVersion("0.2-1")))));
+    assertThat(new RPackageVersion("1.0-0"), is(not(equalTo(new RPackageVersion("1.0-1")))));
+    assertThat(new RPackageVersion("1.2-0"), is(not(equalTo(new RPackageVersion("1.0-0")))));
+    assertThat(new RPackageVersion("10.0-0"), is(not(equalTo(new RPackageVersion("10.0-1")))));
+    assertThat(new RPackageVersion("9.9999-9999"), is(not(equalTo(new RPackageVersion("9.9999-9998")))));
+
+    // comparing dot versions to dot-dash versions
+    assertThat(new RPackageVersion("0.0.2"), is(not(equalTo(new RPackageVersion("0.0-1")))));
+    assertThat(new RPackageVersion("0.2.0"), is(not(equalTo(new RPackageVersion("0.1-0")))));
+    assertThat(new RPackageVersion("0.2.2"), is(not(equalTo(new RPackageVersion("0.2-1")))));
+    assertThat(new RPackageVersion("1.0.0"), is(not(equalTo(new RPackageVersion("1.0-1")))));
+    assertThat(new RPackageVersion("1.2.0"), is(not(equalTo(new RPackageVersion("1.0-0")))));
+    assertThat(new RPackageVersion("10.0.0"), is(not(equalTo(new RPackageVersion("10.0-1")))));
+    assertThat(new RPackageVersion("9.9999.9999"), is(not(equalTo(new RPackageVersion("9.9999-9998")))));
+
+    // comparing dot-dash versions to dot versions
+    assertThat(new RPackageVersion("0.0-2"), is(not(equalTo(new RPackageVersion("0.0.1")))));
+    assertThat(new RPackageVersion("0.2-0"), is(not(equalTo(new RPackageVersion("0.1.0")))));
+    assertThat(new RPackageVersion("0.2-2"), is(not(equalTo(new RPackageVersion("0.2.1")))));
+    assertThat(new RPackageVersion("1.0-0"), is(not(equalTo(new RPackageVersion("1.0.1")))));
+    assertThat(new RPackageVersion("1.2-0"), is(not(equalTo(new RPackageVersion("1.0.0")))));
+    assertThat(new RPackageVersion("10.0-0"), is(not(equalTo(new RPackageVersion("10.0.1")))));
+    assertThat(new RPackageVersion("9.9999-9999"), is(not(equalTo(new RPackageVersion("9.9999.9998")))));
+  }
+
+  @Test
+  public void testComparingLowerVersions() {
+    // comparing dot versions to dot versions
+    assertThat(new RPackageVersion("0.0.1"), is(lessThan(new RPackageVersion("0.0.2"))));
+    assertThat(new RPackageVersion("0.1.0"), is(lessThan(new RPackageVersion("0.2.0"))));
+    assertThat(new RPackageVersion("0.1.1"), is(lessThan(new RPackageVersion("0.2.0"))));
+    assertThat(new RPackageVersion("0.0.1"), is(lessThan(new RPackageVersion("1.0.0"))));
+    assertThat(new RPackageVersion("0.1.0"), is(lessThan(new RPackageVersion("1.0.0"))));
+    assertThat(new RPackageVersion("1.1.0"), is(lessThan(new RPackageVersion("1.2.0"))));
+    assertThat(new RPackageVersion("1.1.9"), is(lessThan(new RPackageVersion("1.2.0"))));
+    assertThat(new RPackageVersion("1.0.0"), is(lessThan(new RPackageVersion("2.0.0"))));
+    assertThat(new RPackageVersion("1.1.0"), is(lessThan(new RPackageVersion("2.0.0"))));
+    assertThat(new RPackageVersion("1.9.9"), is(lessThan(new RPackageVersion("2.0.0"))));
+    assertThat(new RPackageVersion("1.0.0"), is(lessThan(new RPackageVersion("10.0.0"))));
+    assertThat(new RPackageVersion("9.9.9999"), is(lessThan(new RPackageVersion("10.0.0"))));
+    assertThat(new RPackageVersion("9.9999.9999"), is(lessThan(new RPackageVersion("10.0.0"))));
+
+    // comparing dot-dash versions to dot-dash versions
+    assertThat(new RPackageVersion("0.0-1"), is(lessThan(new RPackageVersion("0.0-2"))));
+    assertThat(new RPackageVersion("0.1-0"), is(lessThan(new RPackageVersion("0.2-0"))));
+    assertThat(new RPackageVersion("0.1-1"), is(lessThan(new RPackageVersion("0.2-0"))));
+    assertThat(new RPackageVersion("0.0-1"), is(lessThan(new RPackageVersion("1.0-0"))));
+    assertThat(new RPackageVersion("0.1-0"), is(lessThan(new RPackageVersion("1.0-0"))));
+    assertThat(new RPackageVersion("1.1-0"), is(lessThan(new RPackageVersion("1.2-0"))));
+    assertThat(new RPackageVersion("1.1-9"), is(lessThan(new RPackageVersion("1.2-0"))));
+    assertThat(new RPackageVersion("1.0-0"), is(lessThan(new RPackageVersion("2.0-0"))));
+    assertThat(new RPackageVersion("1.1-0"), is(lessThan(new RPackageVersion("2.0-0"))));
+    assertThat(new RPackageVersion("1.9-9"), is(lessThan(new RPackageVersion("2.0-0"))));
+    assertThat(new RPackageVersion("1.0-0"), is(lessThan(new RPackageVersion("10.0-0"))));
+    assertThat(new RPackageVersion("9.9-9999"), is(lessThan(new RPackageVersion("10.0-0"))));
+    assertThat(new RPackageVersion("9.9999-9999"), is(lessThan(new RPackageVersion("10.0-0"))));
+
+    // comparing dot versions to dot-dash versions
+    assertThat(new RPackageVersion("0.0.1"), is(lessThan(new RPackageVersion("0.0-2"))));
+    assertThat(new RPackageVersion("0.1.0"), is(lessThan(new RPackageVersion("0.2-0"))));
+    assertThat(new RPackageVersion("0.1.1"), is(lessThan(new RPackageVersion("0.2-0"))));
+    assertThat(new RPackageVersion("0.0.1"), is(lessThan(new RPackageVersion("1.0-0"))));
+    assertThat(new RPackageVersion("0.1.0"), is(lessThan(new RPackageVersion("1.0-0"))));
+    assertThat(new RPackageVersion("1.1.0"), is(lessThan(new RPackageVersion("1.2-0"))));
+    assertThat(new RPackageVersion("1.1.9"), is(lessThan(new RPackageVersion("1.2-0"))));
+    assertThat(new RPackageVersion("1.0.0"), is(lessThan(new RPackageVersion("2.0-0"))));
+    assertThat(new RPackageVersion("1.1.0"), is(lessThan(new RPackageVersion("2.0-0"))));
+    assertThat(new RPackageVersion("1.9.9"), is(lessThan(new RPackageVersion("2.0-0"))));
+    assertThat(new RPackageVersion("1.0.0"), is(lessThan(new RPackageVersion("10.0-0"))));
+    assertThat(new RPackageVersion("9.9.9999"), is(lessThan(new RPackageVersion("10.0-0"))));
+    assertThat(new RPackageVersion("9.9999.9999"), is(lessThan(new RPackageVersion("10.0-0"))));
+
+    // comparing dot-dash versions to dot versions
+    assertThat(new RPackageVersion("0.0-1"), is(lessThan(new RPackageVersion("0.0.2"))));
+    assertThat(new RPackageVersion("0.1-0"), is(lessThan(new RPackageVersion("0.2.0"))));
+    assertThat(new RPackageVersion("0.1-1"), is(lessThan(new RPackageVersion("0.2.0"))));
+    assertThat(new RPackageVersion("0.0-1"), is(lessThan(new RPackageVersion("1.0.0"))));
+    assertThat(new RPackageVersion("0.1-0"), is(lessThan(new RPackageVersion("1.0.0"))));
+    assertThat(new RPackageVersion("1.1-0"), is(lessThan(new RPackageVersion("1.2.0"))));
+    assertThat(new RPackageVersion("1.1-9"), is(lessThan(new RPackageVersion("1.2.0"))));
+    assertThat(new RPackageVersion("1.0-0"), is(lessThan(new RPackageVersion("2.0.0"))));
+    assertThat(new RPackageVersion("1.1-0"), is(lessThan(new RPackageVersion("2.0.0"))));
+    assertThat(new RPackageVersion("1.9-9"), is(lessThan(new RPackageVersion("2.0.0"))));
+    assertThat(new RPackageVersion("1.0-0"), is(lessThan(new RPackageVersion("10.0.0"))));
+    assertThat(new RPackageVersion("9.9-9999"), is(lessThan(new RPackageVersion("10.0.0"))));
+    assertThat(new RPackageVersion("9.9999-9999"), is(lessThan(new RPackageVersion("10.0.0"))));
+  }
+}

--- a/src/test/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilderTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.repository.r.internal;
+
+import java.util.Map;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.common.collect.NestedAttributesMap;
+import org.sonatype.nexus.repository.storage.Asset;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_DEPENDS;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_IMPORTS;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_LICENSE;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_NEEDS_COMPILATION;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_PACKAGE;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_SUGGESTS;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_VERSION;
+
+/**
+ * {@link RPackagesBuilder} unit tests.
+ */
+public class RPackagesBuilderTest
+    extends TestSupport
+{
+  @Test
+  public void buildPackages() {
+    RPackagesBuilder underTest = new RPackagesBuilder("/foo/bar/PACKAGES");
+    underTest.append(createAsset("/foo/x", "x", "1.0.0"));
+    underTest.append(createAsset("/foo/bar/b-4", "b", "4.0.0"));
+    underTest.append(createAsset("/foo/bar/a-1", "a", "1.0.0"));
+    underTest.append(createAsset("/foo/bar/a-3", "a", "3.0.0"));
+    underTest.append(createAsset("/foo/bar/a-2", "a", "2.0.0"));
+    underTest.append(createAsset("/foo/bar/baz/x", "x", "1.0.0"));
+
+    Map<String, Map<String, String>> packageInformation = underTest.getPackageInformation();
+    assertThat(packageInformation.keySet(), contains("a", "b"));
+
+    Map<String, String> packageA = packageInformation.get("a");
+    assertThat(packageA.get(P_PACKAGE), is("a"));
+    assertThat(packageA.get(P_VERSION), is("3.0.0"));
+    assertThat(packageA.get(P_DEPENDS), is("Depends:/foo/bar/a-3"));
+    assertThat(packageA.get(P_IMPORTS), is("Imports:/foo/bar/a-3"));
+    assertThat(packageA.get(P_SUGGESTS), is("Suggests:/foo/bar/a-3"));
+    assertThat(packageA.get(P_LICENSE), is("License:/foo/bar/a-3"));
+    assertThat(packageA.get(P_NEEDS_COMPILATION), is("NeedsCompilation:/foo/bar/a-3"));
+
+    Map<String, String> packageB = packageInformation.get("b");
+    assertThat(packageB.get(P_PACKAGE), is("b"));
+    assertThat(packageB.get(P_VERSION), is("4.0.0"));
+    assertThat(packageB.get(P_DEPENDS), is("Depends:/foo/bar/b-4"));
+    assertThat(packageB.get(P_IMPORTS), is("Imports:/foo/bar/b-4"));
+    assertThat(packageB.get(P_SUGGESTS), is("Suggests:/foo/bar/b-4"));
+    assertThat(packageB.get(P_LICENSE), is("License:/foo/bar/b-4"));
+    assertThat(packageB.get(P_NEEDS_COMPILATION), is("NeedsCompilation:/foo/bar/b-4"));
+  }
+
+  private Asset createAsset(final String assetName, final String packageName, final String packageVersion) {
+    NestedAttributesMap formatAttributes = mock(NestedAttributesMap.class);
+    when(formatAttributes.get(P_PACKAGE, String.class)).thenReturn(packageName);
+    when(formatAttributes.get(P_VERSION, String.class)).thenReturn(packageVersion);
+    when(formatAttributes.get(P_DEPENDS, String.class)).thenReturn("Depends:" + assetName);
+    when(formatAttributes.get(P_IMPORTS, String.class)).thenReturn("Imports:" + assetName);
+    when(formatAttributes.get(P_SUGGESTS, String.class)).thenReturn("Suggests:" + assetName);
+    when(formatAttributes.get(P_LICENSE, String.class)).thenReturn("License:" + assetName);
+    when(formatAttributes.get(P_NEEDS_COMPILATION, String.class)).thenReturn("NeedsCompilation:" + assetName);
+
+    Asset asset = mock(Asset.class);
+    when(asset.formatAttributes()).thenReturn(formatAttributes);
+    when(asset.name()).thenReturn(assetName);
+    return asset;
+  }
+}


### PR DESCRIPTION
Initial attempt to implement correct generation of PACKAGES information for hosted repositories. 

This pull request makes the following changes:
* Adds an RPackageVersion class and associated tests for version comparisons.
* Adds an RPackagesBuilder to do the appropriate building of PACKAGES information for hosted.
* Uses the new RPackagesBuilder in RHostedFacetImpl when PACKAGES.gz requests are serviced.

Note that this could more immediately surface performance issues having to do with regenerating the PACKAGES.gz file on each request, as we have to maintain greatest-version information for each package in memory. My opinion would be that if we like this approach, we should merge it in, but also ensure that someone _volunteers_ to do the work for making the PACKAGES file generation work more like metadata for Yum Hosted.

Note that this seems to pass with the existing tests, but we should test it using actual R packages and the R client before we deem it correct (since we cannot run ITs for our open-source projects at this time). I would test manually (and will do if I have time) but I wanted to at least not let this sit here broken.

It relates to the following issue #s:
* Fixes #12 